### PR TITLE
fork-use/fix-spotlight-positioning-in-modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 /test-results/
 /playwright-report/
 /playwright/.cache/
+.idea

--- a/src/modules/dom.ts
+++ b/src/modules/dom.ts
@@ -214,7 +214,7 @@ export function getElementPosition(
       top += parentTop;
     }
 
-    if (!parent.isSameNode(scrollDocument())) {
+    if (!parent.isSameNode(scrollDocument()) && !hasPosition(element, 'absolute')) {
       top += scrollDocument().scrollTop;
     }
   }


### PR DESCRIPTION
Fix: Prevent setting document scrollTop for spotlight if parent is a modal with absolute positioning